### PR TITLE
Align create date with DB

### DIFF
--- a/src/db/entity.type.ts
+++ b/src/db/entity.type.ts
@@ -1,5 +1,0 @@
-export default interface Entity {
-	id: string;
-}
-
-export type OmitEntity<Type extends Entity> = Partial<Omit<Type, keyof Entity>>;

--- a/src/db/models/user.ts
+++ b/src/db/models/user.ts
@@ -1,4 +1,5 @@
-import type Entity from "../entity.type";
+import type Entity from "../../typings/db/entity";
+import type { ImplyTimestamps } from "../../typings/db/with-timestamps.type";
 import client, { Model, DataTypes } from "../client";
 
 export interface UserTypeRequired {
@@ -15,7 +16,7 @@ export class User extends Model<UserType, UserTypeRequired> {}
 
 export default User;
 
-User.init({
+User.init<ImplyTimestamps<User>>({
 	id: {
 		type: DataTypes.BIGINT,
 		primaryKey: true,

--- a/src/db/models/user.ts
+++ b/src/db/models/user.ts
@@ -1,5 +1,5 @@
 import type Entity from "../../typings/db/entity";
-import type { ImplyTimestamps } from "../../typings/db/with-timestamps.type";
+import type { ImplyTimestamps } from "../../typings/db/with-timestamps";
 import client, { Model, DataTypes } from "../client";
 
 export interface UserTypeRequired {

--- a/src/router/users/router.ts
+++ b/src/router/users/router.ts
@@ -23,11 +23,11 @@ router.route("/")
 		res.json(users);
 	})
 	.post(...validateUsersPost(), async (req: UsersPostRequest, res) => {
-		const userID = await userService.create(req.body);
+		const { id: userID, createdAt } = await userService.create(req.body);
 
 		res.status(201).json({
 			userID,
-			createdAt: new Date().toJSON(),
+			createdAt,
 		});
 	});
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,5 +1,5 @@
 import { Op } from "sequelize";
-import type { OmitEntity } from "../db/entity.type";
+import type Entity from "../typings/db/entity";
 import User, { UserType, UserTypeRequired } from "../db/models/user";
 
 /** @private */
@@ -7,6 +7,15 @@ interface FindQuery {
 	filter?: string;
 	limit?: number;
 }
+
+/** @private */
+interface CreateUserResult {
+	id: string;
+	createdAt: string;
+}
+
+/** @private */
+type AnyProps = Omit<UserType, keyof Entity>;
 
 export default class UserService {
 	private async getRecord(id: string): Promise<User> {
@@ -23,7 +32,7 @@ export default class UserService {
 		return record;
 	}
 
-	private async updateAnyProps(id: string, props: OmitEntity<UserType>): Promise<UserType> {
+	private async updateAnyProps(id: string, props: Partial<AnyProps>): Promise<UserType> {
 		const record = await this.getRecord(id);
 
 		await record.update(props);
@@ -46,10 +55,12 @@ export default class UserService {
 		return records.map((record) => record.get());
 	}
 
-	async create(props: UserTypeRequired): Promise<string> {
+	async create(props: UserTypeRequired): Promise<CreateUserResult> {
 		const record = await User.create(props);
 
-		return record.getDataValue("id");
+		const { id, createdAt } = record.get();
+
+		return { id, createdAt };
 	}
 
 	async get(id: string): Promise<UserType> {

--- a/src/typings/db/entity.ts
+++ b/src/typings/db/entity.ts
@@ -1,0 +1,5 @@
+import type WithTimestamps from "./with-timestamps.type";
+
+export default interface Entity extends WithTimestamps {
+	id: string;
+}

--- a/src/typings/db/entity.ts
+++ b/src/typings/db/entity.ts
@@ -1,4 +1,4 @@
-import type WithTimestamps from "./with-timestamps.type";
+import type WithTimestamps from "./with-timestamps";
 
 export default interface Entity extends WithTimestamps {
 	id: string;

--- a/src/typings/db/with-timestamps.ts
+++ b/src/typings/db/with-timestamps.ts
@@ -10,7 +10,5 @@ export default interface WithTimestamps {
  * skipping explicit validation for the `createdAt` and `updatedAt` properties of the model,
  * because, frankly, this should be done by Sequelize itself somewhere under the hood 🤷‍♀️
  */
-export type ImplyTimestamps<
-	M extends Model,
-> =
+export type ImplyTimestamps<M extends Model> =
 	Model<Omit<M["_attributes"], keyof WithTimestamps>, M["_creationAttributes"]>

--- a/src/typings/db/with-timestamps.type.ts
+++ b/src/typings/db/with-timestamps.type.ts
@@ -1,0 +1,16 @@
+import type { Model } from "sequelize";
+
+export default interface WithTimestamps {
+	createdAt: string;
+	updatedAt: string;
+}
+
+/**
+ * @deprecated (using "deprecated" loosely here) This type is a dirty hack. Basically, it allows
+ * skipping explicit validation for the `createdAt` and `updatedAt` properties of the model,
+ * because, frankly, this should be done by Sequelize itself somewhere under the hood 🤷‍♀️
+ */
+export type ImplyTimestamps<
+	M extends Model,
+> =
+	Model<Omit<M["_attributes"], keyof WithTimestamps>, M["_creationAttributes"]>


### PR DESCRIPTION
Align the value of `createdAt` property in response to `POST /users` with the value that actually gets in DB after the creation.