### PR TITLE
Designate envs by "local" and "remote"

### DIFF
--- a/env/local.ts
+++ b/env/local.ts
@@ -4,6 +4,6 @@ import { options } from "./common";
 
 load({
 	...options,
-	path: resolve(__dirname, ".env.development"),
+	path: resolve(__dirname, ".env.local"),
 	silent: false,
 });

--- a/env/remote.js
+++ b/env/remote.js
@@ -1,5 +1,5 @@
-// Production environment variables are set up via Heroku application settings
-//   https://dashboard.heroku.com/apps/shrouded-bayou-97400/settings
+// Environment variables are set up via Heroku application settings
+//   https://dashboard.heroku.com/apps/{APP_ID}/settings
 
 "use strict";
 
@@ -10,5 +10,5 @@ const { options } = require("./common");
 
 env.load({
 	...options,
-	path: path.resolve(__dirname, ".env.production"),
+	path: path.resolve(__dirname, ".env.remote"),
 });

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "build": "tsc --project ./tsconfig.production.json",
     "postbuild": "del-cli dist/**/*.type.js* dist/typings",
     "lint": "eslint --ext .js,.ts src",
-    "FIXME:": "change ./env/common to ./env/production",
+    "FIXME:": "change ./env/common to ./env/remote",
     "start": "node --require ./env/common.js dist/index.js",
-    "dev": "nodemon --ext json,ts --require ./env/development.ts src/index.ts",
+    "dev": "nodemon --ext json,ts --require ./env/local.ts src/index.ts",
     "preplay": "touch src/playground.ts",
-    "play": "nodemon --ext json,ts --require ./env/development.ts src/playground.ts"
+    "play": "nodemon --ext json,ts --require ./env/local.ts src/playground.ts"
   },
   "devDependencies": {
     "@types/express": "4.17.11",


### PR DESCRIPTION
The reason for this is that the file "/env/production.js" is actually supposed to be loaded not only on production environment, but on any other non-local environment as well, such as production, staging (maybe others in the future, like qa, or pre-prod)